### PR TITLE
Add UGREEN DXP4800 GT support (blocked by miskcoo#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The driver supports these UGREEN NAS models:
 - **DX4700** series
 - **DXP2800** series
 - **DXP4800** series
+- **DXP4800 GT** (tested) - AMD-based; LED MCU on a Synopsys DesignWare I2C bus (see note below)
 - **DXP8800** series (tested on DXP8800 Plus)
 - **DXP480T** series (tested on DXP480T Plus) - uses static white LED only
 
@@ -64,6 +65,7 @@ The driver supports these UGREEN NAS models:
 ### Special Cases
 - **DXP480T Model**: Uses a special static white LED configuration instead of dynamic monitoring
 - **Model-Specific Mapping**: Different models may use different disk-to-LED mappings (e.g., DXP6800 has custom mapping)
+- **DXP4800 GT**: This AMD-based model puts the LED MCU on a Synopsys DesignWare I2C controller (`AMDI0010`) instead of the Intel SMBus adapter the other models use, and that bus driver is not built into the stock Unraid kernel. The plugin therefore also builds and loads the `i2c-designware-core` / `i2c-designware-platform` modules, and locates the MCU by its chip id (`0xc5b2` at register `0x5a`) rather than by adapter name. Requires the chip-id-gated SMBus block-write framing in the underlying `led-ugreen` driver (from `miskcoo/ugreen_leds_controller`); without it the GT's LEDs read but do not respond to writes.
 
 ## Configuration Options
 

--- a/source/compile.sh
+++ b/source/compile.sh
@@ -3,6 +3,9 @@ mkdir -p /UGREENLEDS/lib/modules/${UNAME}/extra
 cd ${DATA_DIR}
 git clone https://github.com/miskcoo/ugreen_dx4600_leds_controller
 cd ${DATA_DIR}/ugreen_dx4600_leds_controller
+# NOTE: DXP4800 GT support requires the chip-id-gated SMBus block-write framing
+# in led-ugreen. That must be present on this ref or the GT's LEDs will read but
+# not write. Tracking PR: miskcoo/ugreen_leds_controller#100 (AMD/DesignWare).
 git checkout master
 PLUGIN_VERSION="$(git log -1 --format="%cs" | sed 's/-//g')"
 
@@ -10,6 +13,25 @@ PLUGIN_VERSION="$(git log -1 --format="%cs" | sed 's/-//g')"
 cd ${DATA_DIR}/ugreen_dx4600_leds_controller/kmod
 make -j${CPU_COUNT}
 cp ${DATA_DIR}/ugreen_dx4600_leds_controller/kmod/led-ugreen.ko /UGREENLEDS/lib/modules/${UNAME}/extra/
+
+# AMD-based models (e.g. DXP4800 GT) need the Synopsys DesignWare I2C bus
+# driver, which the stock Unraid kernel does not build. Compile it as a module
+# from the prepared kernel source so the LED MCU's bus is available.
+KERNEL_SRC="${DATA_DIR}/linux-${UNAME}"
+if [ -d "${KERNEL_SRC}" ]; then
+  ( cd "${KERNEL_SRC}"
+    ./scripts/config --module CONFIG_I2C_DESIGNWARE_CORE \
+                     --module CONFIG_I2C_DESIGNWARE_PLATFORM
+    make olddefconfig
+    make modules_prepare
+    make M=drivers/i2c/busses -j${CPU_COUNT} \
+      CONFIG_I2C_DESIGNWARE_CORE=m CONFIG_I2C_DESIGNWARE_PLATFORM=m modules )
+  cp "${KERNEL_SRC}"/drivers/i2c/busses/i2c-designware-core.ko \
+     "${KERNEL_SRC}"/drivers/i2c/busses/i2c-designware-platform.ko \
+     /UGREENLEDS/lib/modules/${UNAME}/extra/
+else
+  echo "WARNING: kernel source ${KERNEL_SRC} not found; skipping DesignWare modules (DXP4800 GT will not work)"
+fi
 
 #Compress module
 while read -r line

--- a/source/usr/bin/ugreen-leds
+++ b/source/usr/bin/ugreen-leds
@@ -59,6 +59,37 @@ default_modules() {
   sleep 2
 }
 
+# AMD-based models (e.g. DXP4800 GT) put the LED MCU on a Synopsys DesignWare
+# I2C controller instead of the Intel "SMBus I801 adapter". Load the DesignWare
+# bus driver and locate the MCU by its chip id (0xc5b2 at register 0x5a) rather
+# than by adapter name, since the bus number is not fixed.
+gt_modules() {
+  /sbin/modprobe i2c-dev
+  /sbin/modprobe i2c-designware-core 2>/dev/null
+  /sbin/modprobe i2c-designware-platform 2>/dev/null
+  /sbin/modprobe led-ugreen
+  sleep 1
+
+  local d b I2C_BUS=""
+  for d in /sys/class/i2c-dev/i2c-*; do
+    b=$(basename "$d" | sed 's/i2c-//')
+    if [ "$(i2cget -y "$b" 0x3a 0x5a w 2>/dev/null)" = "0xc5b2" ]; then
+      I2C_BUS=$b
+      break
+    fi
+  done
+
+  if [ -z "${I2C_BUS}" ]; then
+    logger "ugreen-leds: Error: LED MCU (chip id 0xc5b2) not found on any i2c bus"
+    return 1
+  fi
+  logger "ugreen-leds: Info: LED MCU found on i2c-${I2C_BUS}"
+  echo "led-ugreen 0x3a" > /sys/bus/i2c/devices/i2c-${I2C_BUS}/new_device 2>/dev/null
+  /sbin/modprobe ledtrig-oneshot
+  /sbin/modprobe ledtrig-netdev
+  sleep 2
+}
+
 default_netdevmon() {
   echo netdev > /sys/class/leds/netdev/trigger
   echo ${INTERFACE} > /sys/class/leds/netdev/device_name
@@ -103,6 +134,12 @@ case "${product_name}" in
   DXP2800*) 
     logger "ugreen-leds: Info: UGREEN DXP2800 series"
     default_modules
+    default_netdevmon
+    ;;
+  "DXP4800 GT")   # AMD-based, LED MCU on Synopsys DesignWare bus
+    logger "ugreen-leds: Info: Found UGREEN DXP4800 GT"
+    hctl_map=("1:0:0:0" "2:0:0:0" "3:0:0:0" "4:0:0:0")
+    gt_modules || exit 1
     default_netdevmon
     ;;
   DXP4800*) 

--- a/ugreenleds-driver.plg
+++ b/ugreenleds-driver.plg
@@ -17,6 +17,11 @@
 
 <CHANGES>
 
+###(unreleased)
+- Add support for DXP4800 GT (AMD-based; LED MCU on a Synopsys DesignWare I2C
+  bus). Builds and loads the i2c-designware bus modules and detects the MCU by
+  chip id. Requires the chip-id-gated write framing in led-ugreen (miskcoo).
+
 ###2024.07.12
 - Increase the interval from netdev to 500ms
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by upstream — do not merge/release yet.** This depends on
> [miskcoo/ugreen_leds_controller#100](https://github.com/miskcoo/ugreen_leds_controller/pull/100),
> which adds the chip-id-gated SMBus block-write framing the GT's MCU needs.
> This plugin builds `led-ugreen` from miskcoo `master` (`compile.sh`), so until
> #100 is merged a build here produces the **unpatched** driver and the GT's LEDs
> will read but not respond to writes. Please hold until #100 lands.

## Summary

Adds support for the **UGREEN DXP4800 GT**. Unlike the existing (Intel-based)
models, the GT is AMD-based: its LED MCU sits on a **Synopsys DesignWare** I2C
controller (ACPI `AMDI0010`) rather than the Intel *SMBus I801 adapter*, and
that bus driver is **not built into the stock Unraid kernel**.

## Changes

- **`source/usr/bin/ugreen-leds`**: add a `"DXP4800 GT"` case — placed *before*
  the `DXP4800*` glob so it isn't swallowed — with its HCTL disk map, and a
  `gt_modules()` that loads `i2c-designware-core`/`i2c-designware-platform` and
  locates the MCU by its **chip id** (`0xc5b2` at register `0x5a`) instead of by
  adapter name (the DesignWare bus number is not fixed).
- **`source/compile.sh`**: also build `i2c-designware-core.ko` and
  `i2c-designware-platform.ko` from the prepared kernel source and bundle them,
  so the MCU's bus is available on the GT.
- **`README.md` / `ugreenleds-driver.plg`**: document the model and the
  DesignWare bus dependency.

Existing models' code paths are untouched (the new case is matched before the
generic glob; everything else falls through to the existing logic).

## Dependency

Requires the chip-id-gated SMBus block-write framing in `led-ugreen`
(miskcoo/ugreen_leds_controller#100). Without it the GT's MCU ACKs writes but
ignores them (reads work, writes don't).

## Note

I left the plugin `<version>` and `<md5>` unchanged, since regenerating the
package is part of your release process — happy to adjust anything here
however you prefer.

## Testing

Tested on a **UGREEN DXP4800 GT** (Unraid 7.3.1, kernel 6.18.33), with the
patched `led-ugreen` from #100: DesignWare modules load, the MCU is
auto-detected on the DesignWare bus, disk LEDs map by HCTL (verified bays 1 and
3 with the two installed drives), and the netdev LED tracks link speed
(2.5G → yellow). The `compile.sh` DesignWare build step mirrors the existing
`led-ugreen.ko` build pattern and runs in the kernel build container; I verified
the produced modules load and work on the target hardware but could not run the
full package-build CI myself — worth a maintainer build check.
